### PR TITLE
Fix unexpected tab close, improve side nav

### DIFF
--- a/src/components/SideNav/SideNav.scss
+++ b/src/components/SideNav/SideNav.scss
@@ -40,19 +40,41 @@
         transform: translateX(-400px);
         margin-right: -30px;
 
-        & > header > button {
+        & > .openmenu-button {
             transition: position 200ms ease;
-            right: calc(-386px);
+            right: calc(-396px);
         }
 
         &.open {
             width: 100%;
             transform: translateX(0);
 
-            & > header > button {
+            & .openmenu-button {
                 right: unset;
             }
         }
+    }
+}
+[data-theme=dark] nav.navbar-wrapper {
+    background-color: var(--slate-800, #1e293b);
+    box-shadow: 4px 0px 4px 0px rgba(0, 0, 0, 0.1);
+}
+
+.openmenu-button {
+    display: none;
+    // border: none;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+
+    @media (max-width: 1024px) {
+        display: flex;
+    }
+}
+
+.closemenu-button {
+    @media (min-width: 1024px) {
+        display: none;
     }
 }
 
@@ -63,7 +85,7 @@
     margin-bottom: 10px;
     padding: 10px;
     display: flex;
-    gap: 0px;
+    gap: 10px;
     align-items: center;
     font-size: 16px;
     text-decoration: none;
@@ -79,8 +101,11 @@
         width: 22px;
         height: 22px;
     }
-
-    &.open {
-        gap: 10px;
+}
+[data-theme=dark] a.navbar-buttons {
+    background-color: var(--slate-800, #1e293b);
+    &.active {
+        background-color: var(--slate-700, #334155);
+        box-shadow: 4px 0px 4px 0px rgba(0, 0, 0, 0.1);
     }
 }

--- a/src/components/SideNav/SideNav.tsx
+++ b/src/components/SideNav/SideNav.tsx
@@ -129,7 +129,7 @@ const SideNav: React.FC = () => {
                             <p
                                 className={`text-start m-0 transition-[font-size] font-inter text-lg font-medium`}
                             >
-                                {(user.name as string) || 'Unknown User'}
+                                {user.name as string}
                             </p>
                             <p className={`text-start text-base m-0 transition-[font-size]`}>
                                 {user.email}

--- a/src/components/SideNav/SideNav.tsx
+++ b/src/components/SideNav/SideNav.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { Flipper, Flipped } from 'react-flip-toolkit';
 import './SideNav.scss';
 import { Link, NavLink } from 'react-router-dom';
 import { useConfig } from 'payload/dist/admin/components/utilities/Config';
@@ -13,76 +12,108 @@ import FileCheck from '../../assets/file-check.svg';
 import FileEdit from '../../assets/file-edit.svg';
 import MailPlus from '../../assets/mail-plus.svg';
 import Users from '../../assets/users.svg';
-import Caret from '../svgs/Caret';
 
 const SideNav: React.FC = () => {
-   
+    const [isOpen, setIsOpen] = useState(false);
+
     const { user } = useAuth();
 
     const {
         routes: { admin },
     } = useConfig();
 
+    const close = () => {
+        setIsOpen(false);
+    };
+
+    const toggleMenu = () => {
+        setIsOpen(!isOpen);
+    };
+
     return (
-        <nav className={`navbar-wrapper relative open'`}>
+        <nav className={`navbar-wrapper relative ${isOpen ? 'open' : ''}`}>
+
+            {!isOpen && (
+                <button
+                    onClick={toggleMenu}
+                    className="w-10 h-14 openmenu-button absolute top-1/2 bg-gray-200 dark:bg-slate-800 hover:bg-gray-300 dark:hover:bg-slate-700 rounded-r-lg shadow-lg text-center"
+                    aria-label="Open menu"
+                >
+                    <div className="">
+                        <div className="flex flex-col items-center justify-center h-full">
+                            <div className="w-1 h-2 bg-gray-400 rounded mb-1"></div>
+                            <div className="w-1 h-2 bg-gray-400 rounded"></div>
+                        </div>
+                    </div>
+                </button>
+            )}
+
             <header>
+                <div className="dark:bg-gray-200 p-4">
                 <img className="h-15" src={Logo} alt="Digital Credentials Consortium logo" />
+                </div>
+                <button
+                    onClick={toggleMenu}
+                    className="closemenu-button absolute top-4 right-4 w-12 h-12 bg-gray-200 hover:bg-gray-300 rounded-full shadow-md flex items-center justify-center transition-all"
+                    aria-label="Close menu"
+                >
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="h-5 w-5 text-gray-600"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                    >
+                        <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M6 18L18 6M6 6l12 12"
+                        />
+                    </svg>
+                </button>
             </header>
 
             <section>
                 <NavLink
-                    className={`navbar-buttons open`}
+                    className="navbar-buttons"
                     to="/admin/collections/credential-batch"
                     onClick={close}
                 >
                     <img src={ListChecks} alt="credential-batch" />{' '}
-                    <span className={`transition-[font-size]`}>
-                        Issuance Overview
-                    </span>
+                    <span className={`transition-[font-size]`}>Issuance Overview</span>
                 </NavLink>
 
                 <NavLink
-                    className={`navbar-buttons open`}
+                    className="navbar-buttons"
                     to="/admin/collections/credential"
                     onClick={close}
                 >
                     <img src={FileCheck} alt="credential" />
-                    <span className={`transition-[font-size]`}>
-                        Credentials
-                    </span>
+                    <span className={`transition-[font-size]`}>Credentials</span>
                 </NavLink>
 
                 <NavLink
-                    className={`navbar-buttons open`}
+                    className="navbar-buttons"
                     to="/admin/collections/credential-template"
                     onClick={close}
                 >
                     <img src={FileEdit} alt="credential-template" />{' '}
-                    <span className={`transition-[font-size]`}>
-                        Credential Templates
-                    </span>
+                    <span className={`transition-[font-size]`}>Credential Templates</span>
                 </NavLink>
 
                 <NavLink
-                    className={`navbar-buttons open`}
+                    className="navbar-buttons"
                     to="/admin/collections/email-template"
                     onClick={close}
                 >
                     <img src={MailPlus} alt="email-template" />
-                    <span className={`transition-[font-size]`}>
-                        Email Templates
-                    </span>
+                    <span className={`transition-[font-size]`}>Email Templates</span>
                 </NavLink>
 
-                <NavLink
-                    className={`navbar-buttons open`}
-                    to="/admin/collections/users"
-                    onClick={close}
-                >
+                <NavLink className="navbar-buttons" to="/admin/collections/users" onClick={close}>
                     <img src={Users} alt="users" />
-                    <span className={`transition-[font-size]`}>
-                        Users
-                    </span>
+                    <span className={`transition-[font-size]`}>Users</span>
                 </NavLink>
             </section>
 
@@ -98,11 +129,9 @@ const SideNav: React.FC = () => {
                             <p
                                 className={`text-start m-0 transition-[font-size] font-inter text-lg font-medium`}
                             >
-                                {user.name}
+                                {(user.name as string) || 'Unknown User'}
                             </p>
-                            <p
-                                className={`text-start text-base m-0 transition-[font-size]`}
-                            >
+                            <p className={`text-start text-base m-0 transition-[font-size]`}>
                                 {user.email}
                             </p>
                         </section>
@@ -111,7 +140,6 @@ const SideNav: React.FC = () => {
 
                 <section>
                     <Logout
-                        
                         className={`flex justify-center transition-[gap] gap-2`}
                         textClassName={`text-xl transition-[font-size]`}
                     />


### PR DESCRIPTION
Sometimes the tab would close when a user clicked the side nav button, which called `close`. This was supposed to be a locally defined function. In at least some browsers, it sometimes closed the tab or window. 

The missing close function turned out to be part of a partially complete mobile menu. I completed the buttons, improved the look a little bit, and refined colors in dark mode. Colors will need a revisit once theming is updated.

<img width="1248" alt="Screenshot 2025-03-31 at 18 06 46" src="https://github.com/user-attachments/assets/b76b6f54-99bb-4e3c-98e5-29d1005bc4b3" />

<img width="447" alt="Screenshot 2025-03-31 at 18 26 37" src="https://github.com/user-attachments/assets/42b19fe2-1aab-4ad6-a4ca-5aed462b2c09" />
